### PR TITLE
Fix give command for MythicMobs @trigger and improve random amount calculation

### DIFF
--- a/src/main/java/emanondev/itemedit/compability/MythicMobsListener.java
+++ b/src/main/java/emanondev/itemedit/compability/MythicMobsListener.java
@@ -308,7 +308,10 @@ class GiveServerItemMechanic implements ISkillMechanic, ITargetedEntitySkill {
             ItemEdit.get().log("&9[&fMythicMobs&9] &fInvalid id, '" + id + "' is not a registered serveritem");
             return;
         }
-        item.setAmount((int) (amount + Math.random() * diff));
-        InventoryUtils.giveAmount(player, item, amount, InventoryUtils.ExcessMode.DROP_EXCESS);
+
+        int finalAmount = amount + (int)(Math.random() * (diff + 1));
+
+        item.setAmount(finalAmount);
+        InventoryUtils.giveAmount(player, item, finalAmount, InventoryUtils.ExcessMode.DROP_EXCESS);
     }
 }


### PR DESCRIPTION
Hi,

I made two fixes that did not work with the MythicMobs hook.

* Resolved an issue where give actions failed when the target came from MythicMobs `@trigger`, which provides a `BukkitEntity` not handled by the previous logic.
* Corrected the random amount generation so that the maximum amount can now be produced instead of never being reached.

It has been tested and proven in production for 3 weeks.