### PR TITLE
Add support for ranged item amounts in Give and GiveAll commands

### DIFF
--- a/src/main/java/emanondev/itemedit/command/serveritem/Give.java
+++ b/src/main/java/emanondev/itemedit/command/serveritem/Give.java
@@ -37,7 +37,30 @@ public class Give extends SubCmd {
             if (silent == null) {
                 silent = Boolean.valueOf(args[4]);
             }
-            int amount = args.length >= 3 ? Integer.parseInt(args[2]) : 1;
+            int amount;
+            if (args.length >= 3) {
+                String amountArg = args[2];
+                if (amountArg.contains("-")) {
+                    String[] range = amountArg.split("-");
+                    if (range.length != 2) {
+                        throw new IllegalArgumentException("Invalid range format");
+                    }
+                    try {
+                        int min = Integer.parseInt(range[0]);
+                        int max = Integer.parseInt(range[1]);
+                        if (min < 1 || max < 1 || min > max) {
+                            throw new IllegalArgumentException("Wrong amount range");
+                        }
+                        amount = min + (int) (Math.random() * (max - min + 1));
+                    } catch (NumberFormatException e) {
+                        throw new IllegalArgumentException("Invalid number format in range");
+                    }
+                } else {
+                    amount = Integer.parseInt(amountArg);
+                }
+            } else {
+                amount = 1;
+            }
             if (amount < 1) {
                 throw new IllegalArgumentException("Wrong amount number");
             }
@@ -85,7 +108,7 @@ public class Give extends SubCmd {
             case 2:
                 return CompleteUtility.complete(args[1], ItemEdit.get().getServerStorage().getIds());
             case 3:
-                return CompleteUtility.complete(args[2], Arrays.asList("1", "10", "64", "576", "2304"));
+                return CompleteUtility.complete(args[2], Arrays.asList("1", "10", "64", "576", "2304", "1-10", "1-64"));
             case 4:
                 return CompleteUtility.completePlayers(args[3]);
             case 5:

--- a/src/main/java/emanondev/itemedit/command/serveritem/GiveAll.java
+++ b/src/main/java/emanondev/itemedit/command/serveritem/GiveAll.java
@@ -40,7 +40,30 @@ public class GiveAll extends SubCmd {
             if (silent == null) {
                 silent = Boolean.valueOf(args[3]);
             }
-            int amount = args.length >= 3 ? Integer.parseInt(args[2]) : 1;
+            int amount;
+            if (args.length >= 3) {
+                String amountArg = args[2];
+                if (amountArg.contains("-")) {
+                    String[] range = amountArg.split("-");
+                    if (range.length != 2) {
+                        throw new IllegalArgumentException("Invalid range format");
+                    }
+                    try {
+                        int min = Integer.parseInt(range[0]);
+                        int max = Integer.parseInt(range[1]);
+                        if (min < 1 || max < 1 || min > max) {
+                            throw new IllegalArgumentException("Wrong amount range");
+                        }
+                        amount = min + (int) (Math.random() * (max - min + 1));
+                    } catch (NumberFormatException e) {
+                        throw new IllegalArgumentException("Invalid number format in range");
+                    }
+                } else {
+                    amount = Integer.parseInt(amountArg);
+                }
+            } else {
+                amount = 1;
+            }
             if (amount < 1) {
                 throw new IllegalArgumentException("Wrong amount number");
             }
@@ -104,7 +127,7 @@ public class GiveAll extends SubCmd {
             case 2:
                 return CompleteUtility.complete(args[1], ItemEdit.get().getServerStorage().getIds());
             case 3:
-                return CompleteUtility.complete(args[2], Arrays.asList("1", "10", "64", "576", "2304"));
+                return CompleteUtility.complete(args[2], Arrays.asList("1", "10", "64", "576", "2304", "1-10", "1-64"));
             case 4:
                 return CompleteUtility.complete(args[3], Aliases.BOOLEAN);
         }


### PR DESCRIPTION
This pull request adds support for specifying a random amount range when using the `give` and `giveall` server item commands. Users can now enter an amount as a single number or as a range (e.g., `1-10`), and the command will randomly select an amount within that range. Additionally, tab completion has been updated to suggest common ranges.

**Command functionality improvements:**

* Added support for amount ranges (e.g., `1-10`) in the `give` and `giveall` commands. The code parses the range, validates it, and randomly selects an amount within the specified range.

**Tab completion enhancements:**

* Updated tab completion for the amount argument in both `Give.java` and `GiveAll.java` to suggest common ranges like `1-10` and `1-64`, in addition to single values.

Tested in production. 